### PR TITLE
Ghe lib refactoring

### DIFF
--- a/resources/sdp/libraries/github_enterprise/gh.groovy
+++ b/resources/sdp/libraries/github_enterprise/gh.groovy
@@ -13,10 +13,11 @@ def call() {
 
   withCredentials([usernamePassword(credentialsId: credId, passwordVariable: 'PAT', usernameVariable: 'USER')]) {
     def ghUrlBase = "${env.GIT_URL.split("/")[0..-3].join("/")}"
+    def ghUrl = ''
     if (ghUrlBase =~ /https?:\/\/github\.com/ ) {
-      def ghUrl = "https://api.github.com"
+      ghUrl = "https://api.github.com"
     } else {
-      def ghUrl = "${env.GIT_URL.split("/")[0..-3].join("/")}/api/v3"
+      ghUrl = "${env.GIT_URL.split("/")[0..-3].join("/")}/api/v3"
     }
     return org.kohsuke.github.GitHub.connectToEnterprise(ghUrl, PAT)
   }

--- a/resources/sdp/libraries/github_enterprise/gh.groovy
+++ b/resources/sdp/libraries/github_enterprise/gh.groovy
@@ -6,9 +6,18 @@
 import org.kohsuke.github.*
 
 def call() {
-  withCredentials([usernamePassword(credentialsId: 'github', passwordVariable: 'PAT', usernameVariable: 'USER')]) {
-    def ghUrl = "${env.GIT_URL.split("/")[0..-3].join("/")}/api/v3"
+
+  def credId = scm.getUserRemoteConfigs()[0]?.getCredentialsId() ?:
+               {echo "Could not find CredentialId. Using default ID \"github\""; 'github'}
+
+
+  withCredentials([usernamePassword(credentialsId: credId, passwordVariable: 'PAT', usernameVariable: 'USER')]) {
+    def ghUrlBase - "${env.GIT_URL.split("/")[0..-3].join("/")}"
+    if (ghUrlBase =~ /https?:\/\/github\.com/ ) {
+      def ghUrl = "https://api.github.com"
+    } else {
+      def ghUrl = "${env.GIT_URL.split("/")[0..-3].join("/")}/api/v3"
+    }
     return org.kohsuke.github.GitHub.connectToEnterprise(ghUrl, PAT)
   }
 }
-

--- a/resources/sdp/libraries/github_enterprise/gh.groovy
+++ b/resources/sdp/libraries/github_enterprise/gh.groovy
@@ -12,7 +12,7 @@ def call() {
 
 
   withCredentials([usernamePassword(credentialsId: credId, passwordVariable: 'PAT', usernameVariable: 'USER')]) {
-    def ghUrlBase - "${env.GIT_URL.split("/")[0..-3].join("/")}"
+    def ghUrlBase = "${env.GIT_URL.split("/")[0..-3].join("/")}"
     if (ghUrlBase =~ /https?:\/\/github\.com/ ) {
       def ghUrl = "https://api.github.com"
     } else {

--- a/resources/sdp/libraries/github_enterprise/on_merge.groovy
+++ b/resources/sdp/libraries/github_enterprise/on_merge.groovy
@@ -39,11 +39,14 @@ String get_merged_from(){
   node{
     unstash "git-info"
     // update remote for git name-rev to properly work
+    def credId = scm.getUserRemoteConfigs()[0]?.getCredentialsId() ?:
+                 {echo "Could not find CredentialId. Using default ID \"github\""; 'github'}
+
     def remote = sh(
         script: "git remote -v",
         returnStdout: true
     ).split()[1]
-    withCredentials([usernamePassword(credentialsId: 'github', passwordVariable: 'PASS', usernameVariable: 'USER')]){
+    withCredentials([usernamePassword(credentialsId: credId, passwordVariable: 'PASS', usernameVariable: 'USER')]){
         remote = remote.replaceFirst("://", "://${USER}:${PASS}@")
         sh "git remote rm origin"
         sh "git remote add origin ${remote}"


### PR DESCRIPTION
"github" credential is no longer hard-coded; jobs use the correct one for their GH repo.
github.com's API URL doesn't follow the same pattern as a GHE server's API URL. Updated the `gh()` step to support that.